### PR TITLE
Removed sample/added customEffect attribute

### DIFF
--- a/core-animation.html
+++ b/core-animation.html
@@ -62,7 +62,7 @@ Elements that are targets to a `core-animation` are given the `core-animation-ta
 @status beta
 @homepage github.io
 -->
-<polymer-element name="core-animation" constructor="CoreAnimation" attributes="target keyframes sample composite duration fill easing iterationStart iterationCount delay direction autoplay targetSelector">
+<polymer-element name="core-animation" constructor="CoreAnimation" attributes="target keyframes customEffect composite duration fill easing iterationStart iterationCount delay direction autoplay targetSelector">
   <script>
     (function() {
 


### PR DESCRIPTION
The `sample` attribute isn't used anywhere, and I wanted to declaratively bind a `customEffect` function to a `<core-animation>`. Was this an abandoned attribute?
