### PR TITLE
Ensure this.shadowRoot isn't null

### DIFF
--- a/core-animation.html
+++ b/core-animation.html
@@ -429,7 +429,7 @@ Elements that are targets to a `core-animation` are given the `core-animation-ta
             frames = this.keyframes;
           } else if (!this.customEffect) {
             var children = this.querySelectorAll('core-animation-keyframe');
-            if (children.length === 0) {
+            if (children.length === 0 && this.shadowRoot) {
               children = this.shadowRoot.querySelectorAll('core-animation-keyframe');
             }
             Array.prototype.forEach.call(children, function(c) {


### PR DESCRIPTION
There are some scenarios in which you aren't immediately providing a  `customEffect` (because it's being set dynamically later) and there are no `<core-animation-keyframe>` children, so there won't be a `shadowRoot`. This prevents `this.shadowRoot.querySelectorAll()` from throwing a runtime exception.
