### PR TITLE
Correct repo location for web-animations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "polymer": "Polymer/polymer#master",
-    "web-animations-next": "web-animations/web-animations-next#1.0.1"
+    "web-animations-next": "web-animations/web-animations-js#1.0.1"
   }
 }


### PR DESCRIPTION
github.com/web-animations/web-animations-next is the development repo
releases exist on the github.com/web-animations/web-animations-js repo

Simple fix.
