### PR TITLE
Use latest patched version of web-animations-js 1.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "polymer": "Polymer/polymer#master",
-    "web-animations-js": "web-animations/web-animations-js#1.0.6"
+    "web-animations-js": "web-animations/web-animations-js#1.0.x"
   }
 }


### PR DESCRIPTION
This change will pull in web-animations-js 1.0.8 which includes a fix for TypeErrors on Chrome canary when using AnimationGroups.
See https://github.com/PolymerElements/neon-animation/issues/162 for context.
